### PR TITLE
[WIP] Make Variable and Trainable Parameters Distinct

### DIFF
--- a/surrogates/models/__init__.py
+++ b/surrogates/models/__init__.py
@@ -1,3 +1,3 @@
-from .models import Model, TrainableModel
+from .models import BayesianModel, Model, SurrogateModel
 
-__all__ = [Model, TrainableModel]
+__all__ = [BayesianModel, Model, SurrogateModel]

--- a/surrogates/models/analytical.py
+++ b/surrogates/models/analytical.py
@@ -21,24 +21,24 @@ class StollWerthModel(Model):
 
         assert all(x in required_parameters for x in provided_parameters)
 
-        trainable_parameters = ["epsilon", "sigma", "L", "Q", "temperature"]
+        variable_parameters = ["epsilon", "sigma", "L", "Q", "temperature"]
 
         for provided_parameter in provided_parameters:
-            trainable_parameters.remove(provided_parameter)
+            variable_parameters.remove(provided_parameter)
 
-        super(StollWerthModel, self).__init__(trainable_parameters, fixed_parameters)
+        super(StollWerthModel, self).__init__(variable_parameters, fixed_parameters)
 
     def evaluate(self, properties, parameters):
 
         assert parameters.ndim == 2
-        assert parameters.shape[1] == self.n_trainable_parameters
+        assert parameters.shape[1] == self.n_variable_parameters
 
         all_parameters = {
             x: numpy.array([y] * parameters.shape[0])
             for x, y in zip(self._fixed_labels, self._fixed_parameters)
         }
         all_parameters.update(
-            {x: y for x, y in zip(self._trainable_labels, parameters.T)}
+            {x: y for x, y in zip(self._variable_labels, parameters.T)}
         )
 
         all_parameters = numpy.concatenate(

--- a/surrogates/tests/models/test_trained.py
+++ b/surrogates/tests/models/test_trained.py
@@ -1,13 +1,13 @@
 import numpy
 
 from surrogates.models.trained import GaussianProcessModel
-from surrogates.utils.distributions import Uniform
 
 
 def test_gaussian_process_no_noise():
 
     model = GaussianProcessModel(
-        priors={"a": Uniform(-10, 10), "b": Uniform(-10, 10)},
+        priors={},
+        variable_parameters=["a", "b"],
         fixed_parameters={},
         condition_parameters=True,
         condition_data=True,

--- a/surrogates/utils/plotting.py
+++ b/surrogates/utils/plotting.py
@@ -1,0 +1,99 @@
+import arviz
+import corner
+from matplotlib import pyplot
+
+
+def plot_trace(trace, parameter_labels, show=False):
+    """Use `Arviz` to plot a trace of the variable parameters,
+    alongside a histogram of their distribution.
+
+    Parameters
+    ----------
+    trace: numpy.ndarray
+        The parameter trace with shape=(n_steps, n_variable_parameters)
+    parameter_labels: list of str
+        The names of each parameter in the trace.
+    show: bool
+        If true, the plot will be shown.
+
+    Returns
+    -------
+    matplotlib.pyplot.Figure
+        The plotted figure.
+    """
+
+    trace_dict = {}
+
+    for index, label in enumerate(parameter_labels):
+        trace_dict[label] = trace[:, index]
+
+    data = arviz.convert_to_inference_data(trace_dict)
+
+    axes = arviz.plot_trace(data)
+    figure = axes[0][0].figure
+
+    if show:
+        figure.show()
+
+    return figure
+
+
+def plot_corner(trace, parameter_labels, show=False):
+    """Use `corner` to plot a corner plot of the parameter
+    distributions.
+
+    Parameters
+    ----------
+    trace: numpy.ndarray
+        The parameter trace with shape=(n_steps, n_variable_parameters+1)
+    parameter_labels: list of str
+        The names of each parameter in the trace.
+    show: bool
+        If true, the plot will be shown.
+
+    Returns
+    -------
+    matplotlib.pyplot.Figure
+        The plotted figure.
+    """
+
+    # noinspection PyTypeChecker
+    figure = corner.corner(
+        trace[:, 1 : 1 + len(parameter_labels)],
+        labels=parameter_labels,
+        color="#17becf",
+    )
+
+    if show:
+        figure.show()
+
+    return figure
+
+
+def plot_log_p(log_p, show=False, label="$log p$"):
+    """Plot the log p trace.
+
+    Parameters
+    ----------
+    log_p: numpy.ndarray
+        The log p trace with shape=(n_steps, 1)
+    show: bool
+        If true, the plot will be shown.
+    label: str
+        The y-axis label to use.
+
+    Returns
+    -------
+    matplotlib.pyplot.Figure
+        The plotted figure.
+    """
+    figure, axes = pyplot.subplots(1, 1, figsize=(5, 5), dpi=200)
+
+    axes.plot(log_p, color="#17becf")
+    axes.set_xlabel("steps")
+    axes.set_ylabel(f"{label}")
+
+    if show:
+        figure.show()
+
+    return figure


### PR DESCRIPTION
## Description
This PR extends the model classes to make a distinction between parameters which will be trained during an optimisation, and those that should be specified during calls to `evaluate`.

This PR also bundles a cleanup of the `BayesianModel` object.

## Status
- [X] Ready to go